### PR TITLE
Adopt .NET 10-focused refinements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+bin/
+obj/
+*.user
+*.rsuser
+*.suo
+*.userosscache
+*.sln.docstates

--- a/GMapListToKml.csproj
+++ b/GMapListToKml.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0-rc.1.25451.107" />
+  </ItemGroup>
+</Project>

--- a/Models/GoogleMapsListData.cs
+++ b/Models/GoogleMapsListData.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace GMapListToKml.Models;
+
+/// <summary>
+/// Represents the metadata and places returned from the Google Maps list.
+/// </summary>
+public sealed record GoogleMapsListData(
+    string Name,
+    string? Description,
+    string? Creator,
+    IReadOnlyList<GoogleMapsPlace> Places);
+
+/// <summary>
+/// Represents a single location extracted from the Google Maps list.
+/// </summary>
+public sealed record GoogleMapsPlace(
+    string Name,
+    string? Address,
+    string? Notes,
+    double? Latitude,
+    double? Longitude);

--- a/Options/AppOptions.cs
+++ b/Options/AppOptions.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace GMapListToKml.Options;
+
+/// <summary>
+/// Represents the validated command line options consumed by the application.
+/// </summary>
+public sealed class AppOptions(Uri inputListUri, string? outputFilePath, bool verbose)
+{
+    /// <summary>Gets the required Google Maps list URL.</summary>
+    public Uri InputListUri { get; } = inputListUri ?? throw new ArgumentNullException(nameof(inputListUri));
+
+    /// <summary>Gets the optional destination file path for the generated KML document.</summary>
+    public string? OutputFilePath { get; } = outputFilePath;
+
+    /// <summary>Gets a flag indicating whether verbose/debug logging is enabled.</summary>
+    public bool Verbose { get; } = verbose;
+}

--- a/Options/AppOptionsParser.cs
+++ b/Options/AppOptionsParser.cs
@@ -1,0 +1,116 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace GMapListToKml.Options;
+
+/// <summary>
+/// Parses command line arguments into a strongly typed <see cref="AppOptions"/> instance.
+/// </summary>
+public static class AppOptionsParser
+{
+    private static readonly string[] HelpFlags = ["--help", "-h", "-?", "/?"];
+
+    /// <summary>
+    /// Determines whether the provided argument set is requesting help/usage information.
+    /// </summary>
+    public static bool ShouldShowHelp(string[] args) => args.Any(arg => HelpFlags.Contains(arg, StringComparer.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Attempts to parse the supplied arguments into a validated <see cref="AppOptions"/> instance.
+    /// </summary>
+    public static bool TryParse(string[] args, out AppOptions? options, out string? errorMessage)
+    {
+        string? inputListValue = null;
+        string? outputFileValue = null;
+        var verbose = false;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+
+            if (HelpFlags.Contains(argument, StringComparer.OrdinalIgnoreCase))
+            {
+                // The help case is handled by the caller, so we quietly ignore it here to avoid noise.
+                continue;
+            }
+
+            switch (argument)
+            {
+                case "--inputList":
+                    if (++index >= args.Length)
+                    {
+                        errorMessage = "The --inputList option requires a value.";
+                        options = null;
+                        return false;
+                    }
+
+                    inputListValue = args[index];
+                    break;
+
+                case "--outputFile":
+                    if (++index >= args.Length)
+                    {
+                        errorMessage = "The --outputFile option requires a value.";
+                        options = null;
+                        return false;
+                    }
+
+                    outputFileValue = args[index];
+                    break;
+
+                case "--verbose":
+                    verbose = true;
+                    break;
+
+                default:
+                    if (argument.StartsWith("--", StringComparison.Ordinal))
+                    {
+                        errorMessage = $"Unknown option '{argument}'.";
+                    }
+                    else
+                    {
+                        errorMessage = $"Unexpected argument '{argument}'.";
+                    }
+
+                    options = null;
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(inputListValue))
+        {
+            errorMessage = "The --inputList argument is required.";
+            options = null;
+            return false;
+        }
+
+        if (!Uri.TryCreate(inputListValue, UriKind.Absolute, out var inputListUri))
+        {
+            errorMessage = "The value provided to --inputList must be a valid absolute URL.";
+            options = null;
+            return false;
+        }
+
+        options = new AppOptions(inputListUri, string.IsNullOrWhiteSpace(outputFileValue) ? null : outputFileValue, verbose);
+        errorMessage = null;
+        return true;
+    }
+
+    /// <summary>
+    /// Outputs usage information for the application to the console.
+    /// </summary>
+    public static void PrintUsage()
+    {
+        var executableName = Path.GetFileName(Environment.ProcessPath) ?? "GMapListToKml";
+        Console.WriteLine($"Usage: {executableName} --inputList <url> [--outputFile <path>] [--verbose]");
+        Console.WriteLine();
+        Console.WriteLine("Required arguments:");
+        Console.WriteLine("  --inputList     The Google Maps list URL to download and convert into KML.");
+        Console.WriteLine();
+        Console.WriteLine("Optional arguments:");
+        Console.WriteLine("  --outputFile    Path to the KML file to create. Defaults to the list name with a .kml extension.");
+        Console.WriteLine("  --verbose       Enables verbose logging for troubleshooting.");
+        Console.WriteLine("  --help, -h      Displays this usage information.");
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using GMapListToKml.Options;
+using GMapListToKml.Services;
+using GMapListToKml.Utilities;
+using Microsoft.Extensions.Logging;
+
+namespace GMapListToKml;
+
+/// <summary>
+/// Entry point of the application. Responsible for orchestrating the overall execution flow and
+/// wiring up infrastructure such as logging and HTTP dependencies.
+/// </summary>
+public static class Program
+{
+    /// <summary>
+    /// Main method that coordinates argument parsing, data retrieval, and KML file generation.
+    /// </summary>
+    /// <param name="args">Command line arguments provided by the user.</param>
+    /// <returns>Zero when the application finishes successfully, otherwise a non-zero error code.</returns>
+    public static async Task<int> Main(string[] args)
+    {
+        // A dedicated help flag is easier for users than throwing an error, so we short-circuit early.
+        if (AppOptionsParser.ShouldShowHelp(args))
+        {
+            AppOptionsParser.PrintUsage();
+            return 0;
+        }
+
+        if (!AppOptionsParser.TryParse(args, out var options, out var errorMessage))
+        {
+            if (!string.IsNullOrWhiteSpace(errorMessage))
+            {
+                Console.Error.WriteLine(errorMessage);
+            }
+
+            AppOptionsParser.PrintUsage();
+            return 1;
+        }
+
+        // We immediately store the parsed options in a non-nullable variable so the remainder of the method can use it safely.
+        var appOptions = options ?? throw new InvalidOperationException("Options parsing returned a null result.");
+
+        // The logger factory is built once so every service shares the same formatting and level configuration.
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.ClearProviders();
+            builder.AddSimpleConsole(options =>
+            {
+                options.TimestampFormat = "yyyy-MM-dd HH:mm:ss ";
+                options.SingleLine = true;
+            });
+            builder.SetMinimumLevel(appOptions.Verbose ? LogLevel.Debug : LogLevel.Information);
+        });
+
+        var logger = loggerFactory.CreateLogger(typeof(Program));
+
+        using var cancellation = new CancellationTokenSource();
+        ConsoleCancelEventHandler? cancelHandler = null;
+        cancelHandler = (_, eventArgs) =>
+        {
+            // Cancelling prevents the process from terminating abruptly, giving us time to clean up resources.
+            eventArgs.Cancel = true;
+            if (!cancellation.IsCancellationRequested)
+            {
+                logger.LogWarning("Cancellation requested. Attempting to stop gracefully...");
+                cancellation.Cancel();
+            }
+        };
+
+        Console.CancelKeyPress += cancelHandler;
+
+        try
+        {
+            using var httpClient = CreateHttpClient();
+
+            var scraper = new GoogleMapsListScraper(httpClient, loggerFactory.CreateLogger<GoogleMapsListScraper>());
+            var listData = await scraper.FetchListAsync(appOptions.InputListUri, cancellation.Token).ConfigureAwait(false);
+
+            var outputPath = OutputPathResolver.Resolve(appOptions.OutputFilePath, listData.Name);
+
+            var kmlWriter = new KmlWriter(loggerFactory.CreateLogger<KmlWriter>());
+            await kmlWriter.WriteAsync(listData, outputPath, cancellation.Token).ConfigureAwait(false);
+
+            logger.LogInformation("KML file created at {OutputPath}", outputPath);
+            return 0;
+        }
+        catch (OperationCanceledException)
+        {
+            logger.LogWarning("Operation cancelled by user.");
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An error occurred while generating the KML file.");
+            return 1;
+        }
+        finally
+        {
+            Console.CancelKeyPress -= cancelHandler;
+        }
+    }
+
+    /// <summary>
+    /// Creates and configures an <see cref="HttpClient"/> instance tailored for Google Maps requests.
+    /// </summary>
+    private static HttpClient CreateHttpClient()
+    {
+        // We mimic a standard browser so Google returns the same HTML a user would see in practice.
+        var client = new HttpClient
+        {
+            Timeout = TimeSpan.FromSeconds(45)
+        };
+
+        client.DefaultRequestHeaders.UserAgent.ParseAdd(
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36");
+        client.DefaultRequestHeaders.AcceptLanguage.ParseAdd("en-US,en;q=0.9");
+
+        return client;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # GMapListToKml
-Takes a Google Maps List and Converts it to a KML file (experimental)
+
+GMapListToKml is a .NET 10 console application that downloads one of your public Google Maps lists and exports it as a Keyhole Markup Language (KML) document. The tool focuses on the data embedded inside the `window.APP_INITIALIZATION_STATE` script block, which contains the list name, description, creator, and every place entry.
+
+## Requirements
+
+* [.NET 10 SDK (Release Candidate or later)](https://dotnet.microsoft.com/)
+* Network access to reach `maps.app.goo.gl` and `google.com`
+
+## Usage
+
+```bash
+GMapListToKml --inputList "https://maps.app.goo.gl/Dr5BWZN1Z1RL2fu3A" --outputFile "2023.03.21.MSYDelta.kml"
+```
+
+### Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--inputList <url>` | Yes | Google Maps list URL to download. |
+| `--outputFile <path>` | No  | Destination file name. When omitted, the Google list name is sanitized and used instead. |
+| `--verbose` | No | Enables detailed logging to help troubleshoot scraping issues. |
+| `--help`, `-h` | No | Prints usage information. |
+
+### Example
+
+```bash
+GMapListToKml --inputList "https://maps.app.goo.gl/Dr5BWZN1Z1RL2fu3A" --verbose
+```
+
+The command above will create a file named `2023.03.21.MSYDelta.kml` (based on the list name) in the current directory unless `--outputFile` is specified.
+
+## Notes
+
+* The scraper relies on HtmlAgilityPack so it can robustly locate the initialization script, even if Google changes HTML whitespace or formatting.
+* The generated KML file stores address and notes inside the placemark description. Latitude and longitude are added whenever Google exposes them in the payload.
+* The project embraces .NET 10 preview features such as class primary constructors and collection expressions to keep the implementation concise.

--- a/Services/GoogleMapsListScraper.cs
+++ b/Services/GoogleMapsListScraper.cs
@@ -1,0 +1,304 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using GMapListToKml.Models;
+using HtmlAgilityPack;
+using Microsoft.Extensions.Logging;
+
+namespace GMapListToKml.Services;
+
+/// <summary>
+/// Retrieves a Google Maps list page and translates it into strongly typed models.
+/// </summary>
+public sealed class GoogleMapsListScraper(HttpClient httpClient, ILogger<GoogleMapsListScraper> logger)
+{
+    private readonly HttpClient _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    private readonly ILogger<GoogleMapsListScraper> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    /// <summary>
+    /// Downloads the Google Maps list and extracts its metadata and places.
+    /// </summary>
+    public async Task<GoogleMapsListData> FetchListAsync(Uri listUri, CancellationToken cancellationToken = default)
+    {
+        if (listUri is null)
+        {
+            throw new ArgumentNullException(nameof(listUri));
+        }
+
+        _logger.LogInformation("Downloading Google Maps list from {Uri}", listUri);
+
+        using var response = await _httpClient.GetAsync(listUri, HttpCompletionOption.ResponseContentRead, cancellationToken)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var htmlContent = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+        // HtmlAgilityPack gives us a tolerant DOM-like API which is extremely helpful when working with complex pages.
+        var htmlDocument = new HtmlDocument();
+        htmlDocument.LoadHtml(htmlContent);
+
+        var scriptContent = ExtractInitializationScript(htmlDocument.DocumentNode);
+        if (scriptContent is null)
+        {
+            throw new InvalidOperationException(
+                "Unable to locate the window.APP_INITIALIZATION_STATE script in the retrieved HTML response.");
+        }
+
+        var jsonPayload = ExtractJsonPayload(scriptContent);
+        if (jsonPayload is null)
+        {
+            throw new InvalidOperationException("Failed to isolate the APP_INITIALIZATION_STATE JSON payload.");
+        }
+
+        var rootNode = JsonNode.Parse(jsonPayload) ?? throw new InvalidOperationException("Empty initialization payload.");
+        var listNode = FindListNode(rootNode);
+        if (listNode is null)
+        {
+            throw new InvalidOperationException("Could not locate the list details within the initialization payload.");
+        }
+
+        var listData = ParseListNode(listNode);
+        _logger.LogInformation("Extracted {Count} places from list '{ListName}'.", listData.Places.Count, listData.Name);
+        return listData;
+    }
+
+    /// <summary>
+    /// Searches the DOM for the script element that hosts the initialization data. We use the DOM instead of string search
+    /// to remain resilient to minification or formatting changes in Google's HTML.
+    /// </summary>
+    private string? ExtractInitializationScript(HtmlNode documentNode)
+    {
+        foreach (var scriptNode in documentNode.SelectNodes("//script") ?? [])
+        {
+            var text = scriptNode.InnerText;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                continue;
+            }
+
+            if (text.Contains("window.APP_INITIALIZATION_STATE", StringComparison.Ordinal))
+            {
+                _logger.LogDebug("Found the script node that contains the initialization state block.");
+                return text;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts the JSON array assigned to the global <c>window.APP_INITIALIZATION_STATE</c> variable.
+    /// </summary>
+    private static string? ExtractJsonPayload(string scriptContent)
+    {
+        const string marker = "window.APP_INITIALIZATION_STATE=";
+
+        var markerIndex = scriptContent.IndexOf(marker, StringComparison.Ordinal);
+        if (markerIndex < 0)
+        {
+            return null;
+        }
+
+        var startIndex = scriptContent.IndexOf('[', markerIndex + marker.Length);
+        if (startIndex < 0)
+        {
+            return null;
+        }
+
+        var builder = new StringBuilder();
+        var depth = 0;
+        var inString = false;
+        var isEscaped = false;
+
+        for (var index = startIndex; index < scriptContent.Length; index++)
+        {
+            var character = scriptContent[index];
+            builder.Append(character);
+
+            if (inString)
+            {
+                if (isEscaped)
+                {
+                    isEscaped = false;
+                }
+                else if (character == '\\')
+                {
+                    isEscaped = true;
+                }
+                else if (character == '"')
+                {
+                    inString = false;
+                }
+
+                continue;
+            }
+
+            switch (character)
+            {
+                case '"':
+                    inString = true;
+                    break;
+
+                case '[':
+                    depth++;
+                    break;
+
+                case ']':
+                    depth--;
+                    if (depth == 0)
+                    {
+                        return builder.ToString();
+                    }
+
+                    break;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Recursively traverses the initialization payload looking for the entry that contains the placelist share URL.
+    /// </summary>
+    private JsonArray? FindListNode(JsonNode node)
+    {
+        switch (node)
+        {
+            case JsonArray array:
+                {
+                    if (array.Count >= 6)
+                    {
+                        var shareNode = array.Count > 2 ? array[2] : null;
+                        if (shareNode is JsonArray shareArray && shareArray.Count >= 3)
+                        {
+                            var shareUrl = shareArray[2]?.GetValue<string?>();
+                            if (!string.IsNullOrEmpty(shareUrl) &&
+                                shareUrl.Contains("https://www.google.com/maps/placelists/list/", StringComparison.Ordinal))
+                            {
+                                _logger.LogDebug("Identified share URL '{ShareUrl}' while traversing the payload.", shareUrl);
+                                return array;
+                            }
+                        }
+                    }
+
+                    foreach (var child in array)
+                    {
+                        if (child is JsonNode childNode)
+                        {
+                            var result = FindListNode(childNode);
+                            if (result is not null)
+                            {
+                                return result;
+                            }
+                        }
+                    }
+
+                    break;
+                }
+
+            case JsonObject obj:
+                foreach (var property in obj)
+                {
+                    if (property.Value is JsonNode childNode)
+                    {
+                        var result = FindListNode(childNode);
+                        if (result is not null)
+                        {
+                            return result;
+                        }
+                    }
+                }
+
+                break;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Converts the raw JSON array into domain models that are easier for the rest of the application to consume.
+    /// </summary>
+    private GoogleMapsListData ParseListNode(JsonArray listNode)
+    {
+        var name = listNode.Count > 4 ? listNode[4]?.GetValue<string?>() : null;
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new InvalidOperationException("Unable to determine the list name.");
+        }
+
+        var description = listNode.Count > 5 ? listNode[5]?.GetValue<string?>() : null;
+
+        string? creator = null;
+        if (listNode.Count > 3 && listNode[3] is JsonArray creatorArray && creatorArray.Count > 0)
+        {
+            creator = creatorArray[0]?.GetValue<string?>();
+        }
+
+        List<GoogleMapsPlace> places = [];
+        if (listNode.Count > 8 && listNode[8] is JsonArray placesArray)
+        {
+            places = new List<GoogleMapsPlace>(placesArray.Count);
+            foreach (var placeNode in placesArray)
+            {
+                if (placeNode is JsonArray placeArray)
+                {
+                    var place = ParsePlaceNode(placeArray);
+                    if (place is not null)
+                    {
+                        places.Add(place);
+                    }
+                }
+            }
+        }
+
+        return new GoogleMapsListData(name, description, creator, places);
+    }
+
+    /// <summary>
+    /// Extracts individual pieces of data from a place entry. The Google payload is largely positional, so we defensively
+    /// check the indices before reading anything.
+    /// </summary>
+    private GoogleMapsPlace? ParsePlaceNode(JsonArray placeArray)
+    {
+        var name = placeArray.Count > 2 ? placeArray[2]?.GetValue<string?>() : null;
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            _logger.LogDebug("Encountered a place entry without a name. Skipping it to keep the KML clean.");
+            return null;
+        }
+
+        var notes = placeArray.Count > 3 ? placeArray[3]?.GetValue<string?>() : null;
+
+        string? address = null;
+        double? latitude = null;
+        double? longitude = null;
+
+        if (placeArray.Count > 1 && placeArray[1] is JsonArray locationArray)
+        {
+            address = locationArray.Count > 4 ? locationArray[4]?.GetValue<string?>() : null;
+
+            if (locationArray.Count > 5 && locationArray[5] is JsonArray coordinatesArray)
+            {
+                latitude = TryGetDouble(coordinatesArray, 2);
+                longitude = TryGetDouble(coordinatesArray, 3);
+            }
+        }
+
+        return new GoogleMapsPlace(name, address, notes, latitude, longitude);
+    }
+
+    private static double? TryGetDouble(JsonArray array, int index)
+    {
+        if (array.Count > index && array[index] is JsonValue value && value.TryGetValue<double>(out var number))
+        {
+            return number;
+        }
+
+        return null;
+    }
+}

--- a/Services/KmlWriter.cs
+++ b/Services/KmlWriter.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using GMapListToKml.Models;
+using Microsoft.Extensions.Logging;
+
+namespace GMapListToKml.Services;
+
+/// <summary>
+/// Responsible for translating the parsed Google Maps data into a valid KML document.
+/// </summary>
+public sealed class KmlWriter(ILogger<KmlWriter> logger)
+{
+    private readonly ILogger<KmlWriter> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    /// <summary>
+    /// Writes the provided list to the given file path as a Keyhole Markup Language (KML) document.
+    /// </summary>
+    public async Task WriteAsync(GoogleMapsListData list, string outputPath, CancellationToken cancellationToken = default)
+    {
+        if (list is null)
+        {
+            throw new ArgumentNullException(nameof(list));
+        }
+
+        if (string.IsNullOrWhiteSpace(outputPath))
+        {
+            throw new ArgumentException("Output path must be provided.", nameof(outputPath));
+        }
+
+        _logger.LogDebug("Preparing to write KML file to {OutputPath}.", outputPath);
+
+        var directory = Path.GetDirectoryName(outputPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var settings = new XmlWriterSettings
+        {
+            Async = true,
+            Indent = true,
+            Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)
+        };
+
+        await using var stream = new FileStream(outputPath, FileMode.Create, FileAccess.Write, FileShare.Read);
+        await using var writer = XmlWriter.Create(stream, settings);
+
+        // XML writers buffer data, so we ensure cancellation support by checking the token during long operations.
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await writer.WriteStartDocumentAsync().ConfigureAwait(false);
+        await writer.WriteStartElementAsync(null, "kml", "http://www.opengis.net/kml/2.2").ConfigureAwait(false);
+        await writer.WriteStartElementAsync(null, "Document", null).ConfigureAwait(false);
+
+        await writer.WriteElementStringAsync(null, "name", null, list.Name).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(list.Description))
+        {
+            await writer.WriteElementStringAsync(null, "description", null, list.Description).ConfigureAwait(false);
+        }
+
+        foreach (var place in list.Places)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await WritePlacemarkAsync(writer, place).ConfigureAwait(false);
+        }
+
+        await writer.WriteEndElementAsync().ConfigureAwait(false); // Document
+        await writer.WriteEndElementAsync().ConfigureAwait(false); // kml
+        await writer.WriteEndDocumentAsync().ConfigureAwait(false);
+
+        await writer.FlushAsync().ConfigureAwait(false);
+        _logger.LogDebug("Finished writing {Count} placemarks to {OutputPath}.", list.Places.Count, outputPath);
+    }
+
+    private static async Task WritePlacemarkAsync(XmlWriter writer, GoogleMapsPlace place)
+    {
+        await writer.WriteStartElementAsync(null, "Placemark", null).ConfigureAwait(false);
+        await writer.WriteElementStringAsync(null, "name", null, place.Name).ConfigureAwait(false);
+
+        List<string> descriptionParts = [];
+        if (!string.IsNullOrWhiteSpace(place.Address))
+        {
+            descriptionParts.Add(place.Address!);
+        }
+
+        if (!string.IsNullOrWhiteSpace(place.Notes))
+        {
+            descriptionParts.Add(place.Notes!);
+        }
+
+        if (descriptionParts.Count > 0)
+        {
+            await writer.WriteStartElementAsync(null, "description", null).ConfigureAwait(false);
+            await writer.WriteCDataAsync(string.Join("\n\n", descriptionParts)).ConfigureAwait(false);
+            await writer.WriteEndElementAsync().ConfigureAwait(false);
+        }
+
+        if (place.Latitude.HasValue && place.Longitude.HasValue)
+        {
+            await writer.WriteStartElementAsync(null, "Point", null).ConfigureAwait(false);
+            var coordinates = string.Format(CultureInfo.InvariantCulture, "{0},{1},0", place.Longitude.Value, place.Latitude.Value);
+            await writer.WriteElementStringAsync(null, "coordinates", null, coordinates).ConfigureAwait(false);
+            await writer.WriteEndElementAsync().ConfigureAwait(false);
+        }
+
+        await writer.WriteEndElementAsync().ConfigureAwait(false);
+    }
+}

--- a/Utilities/OutputPathResolver.cs
+++ b/Utilities/OutputPathResolver.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Frozen;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace GMapListToKml.Utilities;
+
+/// <summary>
+/// Converts user input into a safe and absolute file path for the generated KML document.
+/// </summary>
+public static class OutputPathResolver
+{
+    private static readonly FrozenSet<char> InvalidFileNameCharacters = Path.GetInvalidFileNameChars().ToFrozenSet();
+
+    /// <summary>
+    /// Returns the absolute path for the KML file. When no explicit path is provided, the list name is used.
+    /// </summary>
+    public static string Resolve(string? requestedPath, string listName)
+    {
+        if (!string.IsNullOrWhiteSpace(requestedPath))
+        {
+            // We always work with absolute paths to make log statements and error messages unambiguous.
+            return Path.GetFullPath(requestedPath);
+        }
+
+        var sanitizedName = SanitizeFileName(listName);
+        var fileName = sanitizedName.EndsWith(".kml", StringComparison.OrdinalIgnoreCase)
+            ? sanitizedName
+            : sanitizedName + ".kml";
+
+        return Path.GetFullPath(fileName);
+    }
+
+    private static string SanitizeFileName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return "GoogleMapsList";
+        }
+
+        var builder = new StringBuilder(name.Length);
+
+        foreach (var character in name)
+        {
+            builder.Append(InvalidFileNameCharacters.Contains(character) || char.IsControl(character) ? '_' : character);
+        }
+
+        var sanitized = builder.ToString().Trim('_', ' ');
+        return string.IsNullOrEmpty(sanitized) ? "GoogleMapsList" : sanitized;
+    }
+}


### PR DESCRIPTION
## Summary
- update the scraper and KML writer to use class primary constructors and collection expressions provided by the .NET 10/C# preview toolchain
- harden path sanitization with `FrozenSet<char>` lookups to efficiently filter invalid file name characters
- document that the project now embraces modern .NET 10 preview language features

## Testing
- dotnet build *(fails: `dotnet` command not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68caebc1b188833088838270760426b0